### PR TITLE
Adds support for additional security groups

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -55,7 +55,10 @@ resource "aws_launch_template" "main" {
     description                 = "${var.name} ephemeral public ENI"
     subnet_id                   = var.subnet_id
     associate_public_ip_address = true
-    security_groups             = [aws_security_group.main.id]
+    security_groups             = concat(
+      [aws_security_group.main.id],
+      var.additional_security_group_ids
+    )
   }
 
   dynamic "instance_market_options" {

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -1,6 +1,10 @@
 locals {
   name     = "fck-nat-example"
   vpc_cidr = "10.255.255.0/24"
+
+  trusted_networks = [
+    "123.123.123.123/32"
+  ]
 }
 
 data "aws_region" "current" {}
@@ -16,5 +20,18 @@ module "fck-nat" {
   update_route_tables = true
   route_tables_ids = {
     "private" = aws_route_table.private.id
+  }
+
+  additional_security_group_ids = [aws_security_group.additional_security_group.id]
+}
+
+resource "aws_security_group" "additional_security_group" {
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = local.trusted_networks
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -116,3 +116,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "additional_security_group_ids" {
+  description = "A list of identifiers of security groups to be added to the EC2 instance"
+  type = list(string)
+  default = []
+}


### PR DESCRIPTION
A quick PR to add support for additional security groups to the EC2 instance. Just a starting point that it can be built from.