### PR TITLE
Added support for additional VPC cidr block associations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "aws_security_group" "main" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["${data.aws_vpc.main.cidr_block}"]
+    cidr_blocks = data.aws_vpc.main.cidr_block_associations[*].cidr_block
   }
 
   egress {
@@ -43,7 +43,7 @@ resource "aws_security_group" "main" {
 resource "aws_network_interface" "main" {
   description       = "${var.name} static private ENI"
   subnet_id         = var.subnet_id
-  security_groups   = [aws_security_group.main.id]
+  security_groups   = local.security_groups
   source_dest_check = false
 
   tags = merge(var.tags, {


### PR DESCRIPTION
This module currently won't work for VPC's that have multiple CIDR block allocations due to the security group not allowing inbound traffic.

Also fixed (assumably) a typo on the `aws_network_interface` not using security groups passed into the module.