### PR TITLE
Added support for SSM connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ module "fck-nat" {
 | [aws_autoscaling_group.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_iam_instance_profile.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_instance.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_launch_template.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_network_interface.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ module "fck-nat" {
 | [aws_autoscaling_group.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_iam_instance_profile.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_instance.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_launch_template.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_network_interface.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
@@ -73,6 +72,7 @@ module "fck-nat" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_security_group_ids"></a> [additional\_security\_group\_ids](#input\_additional\_security\_group\_ids) | A list of identifiers of security groups to be added for the NAT instance | `list(string)` | `[]` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI to use for the NAT instance. Uses fck-nat latest AMI in the region if none provided | `string` | `null` | no |
+| <a name="input_attach_ssm_policy"></a> [attach\_ssm\_policy](#input\_attach\_ssm\_policy) | Whether to attach the minimum required IAM permissions to connect to the instance via SSM. | `bool` | `true` | no |
 | <a name="input_cloudwatch_agent_configuration"></a> [cloudwatch\_agent\_configuration](#input\_cloudwatch\_agent\_configuration) | CloudWatch configuration for the NAT instance | <pre>object({<br>    namespace           = optional(string, "fck-nat"),<br>    collection_interval = optional(number, 60),<br>    endpoint_override   = optional(string, "")<br>  })</pre> | <pre>{<br>  "collection_interval": 60,<br>  "endpoint_override": "",<br>  "namespace": "fck-nat"<br>}</pre> | no |
 | <a name="input_cloudwatch_agent_configuration_param_arn"></a> [cloudwatch\_agent\_configuration\_param\_arn](#input\_cloudwatch\_agent\_configuration\_param\_arn) | ARN of the SSM parameter containing the CloudWatch agent configuration. If none provided, creates one | `string` | `null` | no |
 | <a name="input_ebs_root_volume_size"></a> [ebs\_root\_volume\_size](#input\_ebs\_root\_volume\_size) | Size of the EBS root volume in GB | `number` | `2` | no |

--- a/examples/full/README.md
+++ b/examples/full/README.md
@@ -29,7 +29,7 @@ $ terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_fck-nat"></a> [fck-nat](#module\_fck-nat) | ../ | n/a |
+| <a name="module_fck-nat"></a> [fck-nat](#module\_fck-nat) | ../../ | n/a |
 
 ## Resources
 

--- a/iam.tf
+++ b/iam.tf
@@ -120,3 +120,8 @@ resource "aws_iam_role" "main" {
 
   tags = var.tags
 }
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.main.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}

--- a/iam.tf
+++ b/iam.tf
@@ -94,6 +94,25 @@ data "aws_iam_policy_document" "main" {
       }
     }
   }
+
+  dynamic "statement" {
+    for_each = var.attach_ssm_policy ? ["x"] : []
+
+    content {
+      sid    = "SessionManager"
+      effect = "Allow"
+      actions = [
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenDataChannel",
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssm:UpdateInstanceInformation",
+      ]
+      resources = [
+        "*"
+      ]
+    }
+  }
 }
 
 resource "aws_iam_role" "main" {
@@ -119,9 +138,4 @@ resource "aws_iam_role" "main" {
   }
 
   tags = var.tags
-}
-
-resource "aws_iam_role_policy_attachment" "ssm" {
-  role       = aws_iam_role.main.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -79,6 +79,12 @@ variable "eip_allocation_ids" {
   default     = []
 }
 
+variable "attach_ssm_policy" {
+  description = "Whether to attach the minimum required IAM permissions to connect to the instance via SSM."
+  type        = bool
+  default     = true
+}
+
 variable "use_spot_instances" {
   description = "Whether or not to use spot instances for running the NAT instance"
   type        = bool


### PR DESCRIPTION
Unsure if you want this configurable by a variable? Considering SSM may become the only method to connect by default (https://github.com/AndrewGuenther/fck-nat/pull/48) I figured there was no harm in attaching the SSM policy by default.

For now, this will only be relevant for users building their own AMI based on your PR to add SSM support.