### PR TITLE
All AZs example

### DIFF
--- a/examples/allazs/README.md
+++ b/examples/allazs/README.md
@@ -1,0 +1,57 @@
+# AllAZs Example
+
+To avoid cross-AZ [data transfer charges](https://aws.amazon.com/ec2/pricing/on-demand/#Data_Transfer_within_the_same_AWS_Region), provide greater [bandwidth](https://fck-nat.dev/stable/choosing_an_instance_size/), and reduce cross-AZ [dependencies](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/zonal-services.html), this example creates a fck-nat instance in each public subnet, and manages the routing table in each AZ's private subnet to use the fck-nat instance in that AZ's public subnet.
+
+This example creates infrastructure from scratch (VPC, public and private subnets in each AZ, IGW) to work and test this Terraform module. In a real
+scenario, you will most probably already have those resources and therefore should only have to focus on calling the
+fck-nat module as done in the [main.tf](main.tf) example source file.
+
+## Usage
+
+To run this example you need to execute:
+```
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_fck-nat"></a> [fck-nat](#module\_fck-nat) | ../ | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_internet_gateway.gw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
+| [aws_route.public_igw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.

--- a/examples/allazs/docs/header.md
+++ b/examples/allazs/docs/header.md
@@ -1,0 +1,16 @@
+# AllAZs Example
+
+To avoid cross-AZ [data transfer charges](https://aws.amazon.com/ec2/pricing/on-demand/#Data_Transfer_within_the_same_AWS_Region), provide greater [bandwidth](https://fck-nat.dev/stable/choosing_an_instance_size/), and reduce cross-AZ [dependencies](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/zonal-services.html), this example creates a fck-nat instance in each public subnet, and manages the routing table in each AZ's private subnet to use the fck-nat instance in that AZ's public subnet.
+
+This example creates infrastructure from scratch (VPC, public and private subnets in each AZ, IGW) to work and test this Terraform module. In a real
+scenario, you will most probably already have those resources and therefore should only have to focus on calling the
+fck-nat module as done in the [main.tf](main.tf) example source file.
+
+## Usage
+
+To run this example you need to execute:
+```
+$ terraform init
+$ terraform plan
+$ terraform apply
+```

--- a/examples/allazs/main.tf
+++ b/examples/allazs/main.tf
@@ -1,0 +1,32 @@
+locals {
+  name     = "fck-nat-allazs"
+  vpc_cidr = "10.255.0.0/16"
+}
+
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "azs" {
+  state = "available"
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+module "fck-nat" {
+  source   = "../../"
+  for_each = toset(data.aws_availability_zones.azs.zone_ids)
+
+  name      = "${local.name}-nat-${each.key}"
+  vpc_id    = aws_vpc.main.id
+  subnet_id = aws_subnet.public[each.key].id
+
+  update_route_tables = true
+  route_tables_ids = {
+    "private" = aws_route_table.private[each.key].id
+  }
+
+  tags = {
+    Name = "${local.name}-fck-nat-${each.key}"
+  }
+}

--- a/examples/allazs/network.tf
+++ b/examples/allazs/network.tf
@@ -1,0 +1,81 @@
+data "aws_availability_zone" "az" {
+  for_each = toset(data.aws_availability_zones.azs.zone_ids)
+  zone_id  = each.key
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = local.vpc_cidr
+
+  tags = {
+    Name = local.name
+  }
+}
+
+### Public
+
+resource "aws_subnet" "public" {
+  for_each          = toset(data.aws_availability_zones.azs.zone_ids)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.255.${substr(each.key, -1, -1)}.0/24"
+  availability_zone = data.aws_availability_zone.az[each.key].name
+
+  tags = {
+    Name = "${local.name}-public-${each.key}"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = local.name
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name}-public"
+  }
+}
+
+resource "aws_route" "public_igw" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.gw.id
+}
+
+resource "aws_route_table_association" "public" {
+  for_each       = toset(data.aws_availability_zones.azs.zone_ids)
+  subnet_id      = aws_subnet.public[each.key].id
+  route_table_id = aws_route_table.public.id
+}
+
+### Private
+
+resource "aws_subnet" "private" {
+  for_each          = toset(data.aws_availability_zones.azs.zone_ids)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.255.${10 + substr(each.key, -1, -1)}.0/24"
+  availability_zone = data.aws_availability_zone.az[each.key].name
+
+  tags = {
+    Name = "${local.name}-private-${each.key}"
+  }
+}
+
+resource "aws_route_table" "private" {
+  for_each = toset(data.aws_availability_zones.azs.zone_ids)
+  vpc_id   = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name}-private-${each.key}"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  for_each       = toset(data.aws_availability_zones.azs.zone_ids)
+  subnet_id      = aws_subnet.private[each.key].id
+  route_table_id = aws_route_table.private[each.key].id
+}

--- a/examples/allazs/provider.tf
+++ b/examples/allazs/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}


### PR DESCRIPTION
Provide an example that creates a `fck-nat` instance in each public subnet, for use by that AZ's private subnet. This avoids cross-AZ [data transfer charges](https://aws.amazon.com/ec2/pricing/on-demand/#Data_Transfer_within_the_same_AWS_Region), provides greater [bandwidth](https://fck-nat.dev/stable/choosing_an_instance_size/), and reduces cross-AZ [dependencies](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/zonal-services.html).