### PR TITLE
Adding SSH Connection Capability to NAT Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ module "fck-nat" {
 | [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+| [aws_key_pair.ssh_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 
 ## Inputs
 
@@ -91,6 +92,9 @@ module "fck-nat" {
 | <a name="input_use_default_security_group"></a> [use\_default\_security\_group](#input\_use\_default\_security\_group) | Whether or not to use the default security group for the NAT instance | `bool` | `true` | no |
 | <a name="input_use_spot_instances"></a> [use\_spot\_instances](#input\_use\_spot\_instances) | Whether or not to use spot instances for running the NAT instance | `bool` | `false` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to deploy the NAT instance into | `string` | n/a | yes |
+| <a name="input_ssh_enabled"></a> [ssh\_enabled](#input\_ssh\_enabled) | Whether or not to allow SSH connections to the NAT instance | `bool` | `false` | no |
+| <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | SSH key to use for the NAT instance. Only valid if ssh_enabled is true | `string` | `null` | no |
+| <a name="input_ssh_public_key_name"></a> [ssh\_public\_key\_name](#input\_ssh\_public\_key\_name) | Name of the SSH key to use for the NAT instance. Only valid if ssh_enabled is true | `string` | `fck-nat-ssh-key` | no |
 
 ## Outputs
 
@@ -104,6 +108,7 @@ module "fck-nat" {
 | <a name="output_eni_id"></a> [eni\_id](#output\_eni\_id) | The ID of the static ENI used by the fck-nat instance |
 | <a name="output_ha_mode"></a> [ha\_mode](#output\_ha\_mode) | Whether or not high-availability mode is enabled via autoscaling group |
 | <a name="output_instance_arn"></a> [instance\_arn](#output\_instance\_arn) | The ARN of the fck-nat instance if running in non-HA mode |
+| <a name="output_instance_public_ip"></a> [instance\_public\_ip](#output\_instance\_public\_ip) | The public IP address of the fck-nat instance if running in non-HA mode |
 | <a name="output_instance_profile_arn"></a> [instance\_profile\_arn](#output\_instance\_profile\_arn) | The ARN of the instance profile used by the fck-nat instance |
 | <a name="output_instance_type"></a> [instance\_type](#output\_instance\_type) | Instance type used for the fck-nat instance |
 | <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | KMS key ID to use for encrypting fck-nat instance EBS volumes |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ module "fck-nat" {
 | [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
-| [aws_key_pair.ssh_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 
 ## Inputs
 
@@ -92,9 +91,8 @@ module "fck-nat" {
 | <a name="input_use_default_security_group"></a> [use\_default\_security\_group](#input\_use\_default\_security\_group) | Whether or not to use the default security group for the NAT instance | `bool` | `true` | no |
 | <a name="input_use_spot_instances"></a> [use\_spot\_instances](#input\_use\_spot\_instances) | Whether or not to use spot instances for running the NAT instance | `bool` | `false` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to deploy the NAT instance into | `string` | n/a | yes |
-| <a name="input_ssh_enabled"></a> [ssh\_enabled](#input\_ssh\_enabled) | Whether or not to allow SSH connections to the NAT instance | `bool` | `false` | no |
-| <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | SSH key to use for the NAT instance. Only valid if ssh_enabled is true | `string` | `null` | no |
-| <a name="input_ssh_public_key_name"></a> [ssh\_public\_key\_name](#input\_ssh\_public\_key\_name) | Name of the SSH key to use for the NAT instance. Only valid if ssh_enabled is true | `string` | `fck-nat-ssh-key` | no |
+| <a name="input_ssh_key_name"></a> [ssh\_key\_name](#input\_ssh\_key\_name) | Name of the SSH key to use for the NAT instance. SSH access will be enabled only if a key name is provided | `string` | `null` | no |
+| <a name="input_ssh_cidr_blocks"></a> [ssh\_cidr\_blocks](#input\_ssh\_cidr\_blocks) | CIDR blocks to allow SSH access to the NAT instance | `list(string)` | `["0.0.0.0/0"]` | no |
 
 ## Outputs
 

--- a/ec2.tf
+++ b/ec2.tf
@@ -31,19 +31,12 @@ data "aws_arn" "ssm_param" {
   arn = var.cloudwatch_agent_configuration_param_arn
 }
 
-resource "aws_key_pair" "ssh_key" {
-  count = var.ssh_enabled ? 1 : 0
-
-  key_name   = var.ssh_public_key_name
-  public_key = var.ssh_public_key
-}
-
 resource "aws_launch_template" "main" {
   name          = var.name
   image_id      = local.ami_id
   instance_type = var.instance_type
 
-  key_name = length(aws_key_pair.ssh_key) != 0 ? aws_key_pair.ssh_key[0].key_name : ""
+  key_name      = var.ssh_key_name
 
   block_device_mappings {
     device_name = "/dev/xvda"

--- a/ec2.tf
+++ b/ec2.tf
@@ -31,10 +31,19 @@ data "aws_arn" "ssm_param" {
   arn = var.cloudwatch_agent_configuration_param_arn
 }
 
+resource "aws_key_pair" "ssh_key" {
+  count = var.ssh_enabled ? 1 : 0
+
+  key_name   = var.ssh_public_key_name
+  public_key = var.ssh_public_key
+}
+
 resource "aws_launch_template" "main" {
   name          = var.name
   image_id      = local.ami_id
   instance_type = var.instance_type
+
+  key_name = length(aws_key_pair.ssh_key) != 0 ? aws_key_pair.ssh_key[0].key_name : ""
 
   block_device_mappings {
     device_name = "/dev/xvda"

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,17 @@ resource "aws_security_group" "main" {
     cidr_blocks = ["${data.aws_vpc.main.cidr_block}"]
   }
 
+  dynamic "ingress" {
+    for_each = var.ssh_enabled ? [1] : []
+    content {
+      description = "SSH ingress from anywhere"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+
   egress {
     description      = "Unrestricted egress"
     from_port        = 0

--- a/main.tf
+++ b/main.tf
@@ -27,13 +27,13 @@ resource "aws_security_group" "main" {
   }
 
   dynamic "ingress" {
-    for_each = var.ssh_enabled ? [1] : []
+    for_each = var.ssh_key_name != null ? [1] : []
     content {
       description = "SSH ingress from anywhere"
       from_port   = 22
       to_port     = 22
       protocol    = "tcp"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_blocks = var.ssh_cidr_blocks
     }
   }
 

--- a/output.tf
+++ b/output.tf
@@ -78,6 +78,11 @@ output "instance_arn" {
   value       = var.ha_mode ? null : aws_instance.main[0].arn
 }
 
+output "instance_public_ip" {
+  description = "The public IP address of the fck-nat instance if running in non-HA mode"
+  value       = var.ha_mode ? null : aws_instance.main[0].public_ip
+}
+
 output "autoscaling_group_arn" {
   description = "The ARN of the autoscaling group if running in HA mode"
   value       = var.ha_mode ? aws_autoscaling_group.main[0].arn : null

--- a/variables.tf
+++ b/variables.tf
@@ -128,3 +128,21 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "ssh_enabled" {
+  description = "Whether or not to allow SSH connections to the NAT instance"
+  type        = bool
+  default     = false
+}
+
+variable "ssh_public_key" {
+  description = "SSH key to use for the NAT instance. Only valid if ssh_enabled is true"
+  type        = string
+  default     = null
+}
+
+variable "ssh_public_key_name" {
+  description = "Name of the SSH key to use for the NAT instance. Only valid if ssh_enabled is true"
+  type        = string
+  default     = "fck-nat-ssh-key"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -129,20 +129,14 @@ variable "tags" {
   default     = {}
 }
 
-variable "ssh_enabled" {
-  description = "Whether or not to allow SSH connections to the NAT instance"
-  type        = bool
-  default     = false
-}
-
-variable "ssh_public_key" {
-  description = "SSH key to use for the NAT instance. Only valid if ssh_enabled is true"
+variable "ssh_key_name" {
+  description = "Name of the SSH key to use for the NAT instance. SSH access will be enabled only if a key name is provided"
   type        = string
   default     = null
 }
 
-variable "ssh_public_key_name" {
-  description = "Name of the SSH key to use for the NAT instance. Only valid if ssh_enabled is true"
-  type        = string
-  default     = "fck-nat-ssh-key"
+variable "ssh_cidr_blocks" {
+  description = "CIDR blocks to allow SSH access to the NAT instance"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
### Overview
This PR introduces the capability to establish SSH connections to the NAT instance. This feature enables users to utilize the existing EC2 instance as an SSH tunnel, offering a cost-effective solution for accessing services on the private VPC, such as RDS instances, without the need to provision additional EC2 instances.

### Motivation
The primary motivation behind this enhancement is to leverage the AWS Free Tier benefits effectively. With the AWS Free Tier providing one EC2 instance, users can now utilize the NAT instance for both its intended purpose and as an SSH tunnel, maximizing the usage of the available resources without incurring additional costs.

### Usage Example
```hcl
module "fck-nat" {
  # ...

  ssh_enabled    = true
  ssh_public_key = file("keys/aws_ec2.pub")
  ssh_public_key_name = "ssh-tunnel-key"
}
```