### PR TITLE
Add checkov scanning, force IMDSv2, update resources to pass scans

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -21,3 +21,15 @@ jobs:
       - name: Terraform Validate
         id: validate
         run: terraform validate -no-color
+
+      - name: Set up Python 3.8 for Checkov
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Test with Checkov
+        id: checkov
+        uses: bridgecrewio/checkov-action@master
+        with:
+          framework: terraform
+          skip_path: ./examples

--- a/ec2.tf
+++ b/ec2.tf
@@ -32,6 +32,7 @@ data "aws_arn" "ssm_param" {
 }
 
 resource "aws_launch_template" "main" {
+  #checkov:skip=CKV_AWS_88:NAT instances must have a public IP.
   name          = var.name
   image_id      = local.ami_id
   instance_type = var.instance_type
@@ -85,10 +86,17 @@ resource "aws_launch_template" "main" {
     TERRAFORM_CWAGENT_CFG_PARAM_NAME = local.cwagent_param_name != null ? local.cwagent_param_name : ""
   }))
 
+  # Enforce IMDSv2
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
   tags = var.tags
 }
 
 resource "aws_instance" "main" {
+  #checkov:skip=CKV2_AWS_41:False positive, IAM role is attached via the launch template.
   count = var.ha_mode ? 0 : 1
 
   launch_template {

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ resource "aws_ssm_parameter" "cloudwatch_agent_config" {
 
   name   = "${var.name}-cloudwatch-agent-config"
   key_id = var.kms_key_id
-  type   = "String"
+  type   = "SecureString"
   value = templatefile("${path.module}/templates/cwagent.json", {
     METRICS_COLLECTION_INTERVAL = var.cloudwatch_agent_configuration.collection_interval,
     METRICS_NAMESPACE           = var.cloudwatch_agent_configuration.namespace


### PR DESCRIPTION
This PR adds [checkov](https://www.checkov.io/) security scanning to the workflow, and update resources to pass the scans. Two resources change, with in-place updates:

* SSM parameter, change from `String` to `SecureString`
* enforce [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) on the NAT instances, which the code is already using ([source](https://github.com/AndrewGuenther/fck-nat/blob/main/service/fck-nat.sh#L10-L15))

There are two skipped checks:
* NAT instances have a public IP on purpose
* Launch template has an IAM instance profile attached, but checkov can't follow that logic