### PR TITLE
Allow enabling cloudwatch auto scaling group metrics collection for HA mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ module "fck-nat" {
   vpc_id               = "vpc-abc1234"
   subnet_id            = "subnet-abc1234"
   # ha_mode              = true                 # Enables high-availability mode
+  # ha_mode_enabled_metrics = ["GroupInServiceInstances"] # Enables specified Cloudwatch metrics collection for high-availability mode
   # eip_allocation_ids   = ["eipalloc-abc1234"] # Allocation ID of an existing EIP
   # use_cloudwatch_agent = true                 # Enables Cloudwatch agent and have metrics reported
 
@@ -78,6 +79,7 @@ module "fck-nat" {
 | <a name="input_eip_allocation_ids"></a> [eip\_allocation\_ids](#input\_eip\_allocation\_ids) | EIP allocation IDs to use for the NAT instance. Automatically assign a public IP if none is provided. Note: Currently only supports at most one EIP allocation. | `list(string)` | `[]` | no |
 | <a name="input_encryption"></a> [encryption](#input\_encryption) | Whether or not to encrypt the EBS volume | `bool` | `true` | no |
 | <a name="input_ha_mode"></a> [ha\_mode](#input\_ha\_mode) | Whether or not high-availability mode should be enabled via autoscaling group | `bool` | `true` | no |
+| <a name="input_ha_mode_enabled_metrics"></a> [ha\_mode\_enabled\_metrics](#input\_ha\_mode\_enabled\_metrics) | Whether or not to enable autoscaling group cloudwatch metrics collection for specified metrics. Disabled by default or when no metrics were provided | `list(string)` | `[]` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type to use for the NAT instance | `string` | `"t4g.micro"` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | Will use the provided KMS key ID to encrypt the EBS volume. Uses the default KMS key if none provided | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name used for resources created within the module | `string` | n/a | yes |

--- a/asg.tf
+++ b/asg.tf
@@ -1,3 +1,7 @@
+locals {
+  asg_cw_metrics_enabled = length(var.ha_mode_enabled_metrics) >= 1
+}
+
 resource "aws_autoscaling_group" "main" {
   count = var.ha_mode ? 1 : 0
 
@@ -7,6 +11,8 @@ resource "aws_autoscaling_group" "main" {
   desired_capacity    = 1
   health_check_type   = "EC2"
   vpc_zone_identifier = [var.subnet_id]
+
+  enabled_metrics = local.asg_cw_metrics_enabled ? var.ha_mode_enabled_metrics : null
 
   launch_template {
     id      = aws_launch_template.main.id

--- a/docs/header.md
+++ b/docs/header.md
@@ -22,6 +22,7 @@ module "fck-nat" {
   vpc_id               = "vpc-abc1234"
   subnet_id            = "subnet-abc1234"
   # ha_mode              = true                 # Enables high-availability mode
+  # ha_mode_enabled_metrics = ["GroupInServiceInstances"] # Enables specified Cloudwatch metrics collection for high-availability mode
   # eip_allocation_ids   = ["eipalloc-abc1234"] # Allocation ID of an existing EIP
   # use_cloudwatch_agent = true                 # Enables Cloudwatch agent and have metrics reported
 

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -12,6 +12,9 @@ module "fck-nat" {
   vpc_id    = aws_vpc.main.id
   subnet_id = aws_subnet.public.id
   ha_mode   = true
+  ha_mode_enabled_metrics = [
+    "GroupInServiceInstances"
+  ]
 
   update_route_tables = true
   route_tables_ids = {

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,12 @@ variable "ha_mode" {
   default     = true
 }
 
+variable "ha_mode_enabled_metrics" {
+  description = "Whether or not to enable autoscaling group cloudwatch metrics collection for specified metrics. Disabled by default or when no metrics were provided"
+  type = list(string)
+  default = []
+}
+
 variable "instance_type" {
   description = "Instance type to use for the NAT instance"
   type        = string


### PR DESCRIPTION
For more serious use and use in production environment I found that I would like to have some way to setup alerts.
It seems Auto Scaling group by default has corresponding metrics collection disabled and its up to the user to either enable allow of them or enable specific ones.

This change allows specifying ( and thus enabling collection ) for specific Auto Scaling group metrics.

> Group metrics are available at one-minute granularity at no additional charge, but you must enable them.

Docs: https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-metrics.html

Example when changes are applied and collection of `GroupInServiceInstances` metric was enabled.
![asg_metrics_working](https://github.com/RaJiska/terraform-aws-fck-nat/assets/187364/a6560ee2-2c36-4435-b262-0ddf63360dd9)
