### PR TITLE
Fix issue causing fck-nat instances to be randomly terminated and not replaced

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -64,6 +64,10 @@ resource "aws_launch_template" "main" {
 
     content {
       market_type = "spot"
+      spot_options {
+        instance_interruption_behavior = "stop"
+        spot_instance_type             = "persistent"
+      }
     }
   }
 


### PR DESCRIPTION
By default, EC2 spot instance requests are "one-time". When the requested spot instance is interrupted, it will be terminated without replacement. terraform-aws-fck-nat does not change this setting. 

Therefore, terraform-aws-fck-nat users who enable `use_spot_instances` will see that, after an unpredictable length of time, their instances get terminated, and require manual intervention to restore.

This PR changes spot instance requests to be "persistent", which means that after a termination, AWS will restore them automatically. It also sets the spot `instance_interruption_behavior` to "stop" because setting it to either "stop" or "hibernate" is a requirement for persistent requests. I didn't choose hibernation because it's probably unnecessary, and it limits which instance types can be used.