### PR TITLE
Don't fail if the instance type architecture is not arm64

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  is_arm             = can(regex("[a-zA-Z]+\\d+g[a-z]*\\..+", var.instance_type))
+  is_arm             = length(regexall("[a-zA-Z]+\\d+g[a-z]*\\..+", var.instance_type)) > 0
   ami_id             = var.ami_id != null ? var.ami_id : data.aws_ami.main[0].id
   cwagent_param_arn  = var.use_cloudwatch_agent ? var.cloudwatch_agent_configuration_param_arn != null ? var.cloudwatch_agent_configuration_param_arn : aws_ssm_parameter.cloudwatch_agent_config[0].arn : null
   cwagent_param_name = var.use_cloudwatch_agent ? var.cloudwatch_agent_configuration_param_arn != null ? split("/", data.aws_arn.ssm_param[0].resource)[1] : aws_ssm_parameter.cloudwatch_agent_config[0].name : null


### PR DESCRIPTION
The ``regex`` function raises an error in case there's no match, so use ``regexall`` instead and check the number of matches.

Fixes #7.