### PR TITLE
Update CloudWatch config to support arbitrary interface names

### DIFF
--- a/templates/cwagent.json
+++ b/templates/cwagent.json
@@ -11,7 +11,7 @@
     %{~ endif ~}
     "metrics_collected": {
       "net": {
-        "resources": ["eth0", "eth1"],
+        "resources": ["*"],
         "measurement": [
           { "name": "bytes_recv", "rename": "BytesIn",  "unit": "Bytes" },
           { "name": "bytes_sent", "rename": "BytesOut",  "unit": "Bytes" },
@@ -29,7 +29,6 @@
         ]
       },
       "ethtool": {
-        "interface_include": ["eth0", "eth1"],
         "metrics_include": [
           "bw_in_allowance_exceeded",
           "bw_out_allowance_exceeded",


### PR DESCRIPTION
After an update to the most recent AMI, I noticed most of our CloudWatch logs for the `fck-nat` namespace are gone. Following an investigation from my side, I saw that the network interfaces are no longer `eth0` and `eth1` but `ens5` and `ens6`. Not sure what caused this change - maybe the AMI update to Amazon Linux 2023. This PR enables metrics for all interfaces, regardless of their name. I tested it and it works.

Relevant docs - https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-network-performance.html
```
interface_include— Including this section causes the agent to collect metrics from only the interfaces that have names listed in this section. If you omit this section, metrics are collected from all Ethernet interfaces that aren't listed in interface_exclude.

The default ethernet interface is eth0.

interface_exclude— If you include this section, list the Ethernet interfaces that you don't want to collect metrics from.

The ethtool plugin always ignores loopback interfaces.
```