### PR TITLE
improve ec2 metadata config

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -89,6 +89,8 @@ resource "aws_launch_template" "main" {
   metadata_options {
     http_endpoint = "enabled"
     http_tokens   = "required"
+    http_put_response_hop_limit = 2
+    instance_metadata_tags      = "enabled"
   }
 
   tags = var.tags


### PR DESCRIPTION
<img width="313" alt="Screenshot 2024-07-11 at 2 57 07 AM" src="https://github.com/RaJiska/terraform-aws-fck-nat/assets/37118134/63347f83-50b5-40ed-925d-61e81a03c334">
 
i am not sure why imdsv2 is showing optional instead of required, i am using the v1.2.0 on terraform registry, although limiting the number of network hops for the PUT responses would reduce SSRF attacks for the ec2.

or will this impact the networking config of fck-nats?