### PR TITLE
Add support for fck-nat v1.3.0

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -6,7 +6,7 @@ data "aws_ami" "main" {
 
   filter {
     name   = "name"
-    values = ["fck-nat-al2023-hvm-*"]
+    values = ["fck-nat-*"]
   }
 
   filter {


### PR DESCRIPTION
The versions later than v1.2.1 have a new AMI naming scheme, to reflect that they're now based on Amazon Linux 2023.

This PR updates the data block which fetches the latest AMI, so that if you don't specify a specific AMI and are just happy with the latest one, then the new AMI will be found.

<img width="2223" alt="image" src="https://github.com/RaJiska/terraform-aws-fck-nat/assets/15341873/5c2d9cf4-bb2a-4431-9a45-bda8004c581d">

As above, the images are now called `fck-nat-al2023-hvm-1.3.0-20240125-arm64-ebs`, which are filtered out from the old filter of `fck-nat-al2023-hvm-*`.

There are other features in 1.3.0 which sound like they also need corresponding Terraform changes to support, but I have not looked into that here.