### PR TITLE
made the example point to the default branch of the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ an ASG
 
 ```hcl
 module "fck-nat" {
-  source = "RaJiska/fck-nat/aws"
+  source = "git::https://github.com/RaJiska/terraform-aws-fck-nat.git" # Use the latest changes in the main branch 
 
   name                 = "my-fck-nat"
   vpc_id               = "vpc-abc1234"


### PR DESCRIPTION
the latest version (v1.2.0) isn't compatible with the example in the readme, updated the example to target the latest commit of the default branch of the repo