### PR TITLE
Update documentation example to point to Git latest version

### DIFF
--- a/docs/header.md
+++ b/docs/header.md
@@ -14,7 +14,7 @@ an ASG
 
 ```hcl
 module "fck-nat" {
-  source = "RaJiska/fck-nat/aws"
+  source = "git::https://github.com/RaJiska/terraform-aws-fck-nat.git"
 
   name                 = "my-fck-nat"
   vpc_id               = "vpc-abc1234"


### PR DESCRIPTION
This is needed as `main` branch will likely always be ahead of the latest version available in Terraform registry resulting in a parameter disconnect between the example and the documentation that comes after.