### PR TITLE
feat: add output for IAM role name

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -63,6 +63,11 @@ output "role_arn" {
   value       = aws_iam_role.main.arn
 }
 
+output "role_name" {
+  description = "The ARN of the role used by the fck-nat instance profile"
+  value       = aws_iam_role.main.name
+}
+
 output "instance_profile_arn" {
   description = "The ARN of the instance profile used by the fck-nat instance"
   value       = aws_iam_instance_profile.main.arn


### PR DESCRIPTION
This commit introduces a new output, "role_name," to the Terraform module. It provides the name of the IAM role associated with the fck-nat instance profile.