### PR TITLE
feat: add support for EC2 instance credit specification

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -37,6 +37,7 @@ resource "aws_launch_template" "main" {
   image_id      = local.ami_id
   instance_type = var.instance_type
   key_name      = var.ssh_key_name
+  credit_specification { cpu_credits = var.credit_specification }
 
   block_device_mappings {
     device_name = "/dev/xvda"

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,12 @@ variable "attach_ssm_policy" {
   default     = true
 }
 
+variable "credit_specification" {
+  description = "Customize the credit specification of the instance"
+  type        = string
+  default     = "standard"
+}
+
 variable "use_spot_instances" {
   description = "Whether or not to use spot instances for running the NAT instance"
   type        = bool


### PR DESCRIPTION
Introduced a new variable `credit_specification` to allow customization of CPU credit options for EC2 instances. Updated the EC2 resource to utilize this variable, defaulting to "standard" for backward compatibility.