### PR TITLE
feat: add `min_size` variable

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -3,7 +3,7 @@ resource "aws_autoscaling_group" "main" {
 
   name                = var.name
   max_size            = 1
-  min_size            = 1
+  min_size            = var.min_size
   desired_capacity    = 1
   health_check_type   = "EC2"
   vpc_zone_identifier = [var.subnet_id]

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,12 @@ variable "ami_id" {
   default     = null
 }
 
+variable "min_size" {
+  description = "Minimum size of the autoscaling group"
+  type        = number
+  default     = 1
+}
+
 variable "ebs_root_volume_size" {
   description = "Size of the EBS root volume in GB"
   type        = number


### PR DESCRIPTION
Introduce a new "min_size" variable to enable control of the Autoscaling Group's minimum size.

Fix for #50.