### PR TITLE
Fixing aws provider v6 deprecation warning

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "main" {
         "ec2:DisassociateAddress",
       ]
       resources = [
-        "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:elastic-ip/${var.eip_allocation_ids[0]}",
+        "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:elastic-ip/${var.eip_allocation_ids[0]}",
       ]
     }
   }
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "main" {
         "ec2:DisassociateAddress",
       ]
       resources = [
-        "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:network-interface/*"
+        "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:network-interface/*"
       ]
       condition {
         test     = "StringEquals"


### PR DESCRIPTION
In v6 version of aws provider there's a note stating

data-source/aws_region: The `name` attribute has been deprecated. All configurations using name should be updated to use the `region` attribute instead (https://github.com/hashicorp/terraform-provider-aws/issues/42131)

This PR fixes this warning (see below)

```
20:02:28.634 STDOUT terraform: │ Warning: Deprecated attribute
20:02:28.634 STDOUT terraform: │
20:02:28.635 STDOUT terraform: │   on .terraform/modules/fck-nat/iam.tf line 37, in data "aws_iam_policy_document" "main":
20:02:28.635 STDOUT terraform: │   37:         "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:elastic-ip/${var.eip_allocation_ids[0]}",
20:02:28.635 STDOUT terraform: │
20:02:28.635 STDOUT terraform: │ The attribute "name" is deprecated. Refer to the provider documentation for
20:02:28.635 STDOUT terraform: │ details.
20:02:28.635 STDOUT terraform: │
20:02:28.635 STDOUT terraform: │ (and one more similar warning elsewhere)
20:02:28.635 STDOUT terraform: ╵
```
