### PR TITLE
instances should use the new launch template after changes

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -10,7 +10,7 @@ resource "aws_autoscaling_group" "main" {
 
   launch_template {
     id      = aws_launch_template.main.id
-    version = "$Latest"
+    version = aws_launch_template.main.latest_version
   }
 
   dynamic "tag" {

--- a/asg.tf
+++ b/asg.tf
@@ -33,6 +33,17 @@ resource "aws_autoscaling_group" "main" {
     }
   }
 
+  dynamic "instance_refresh" {
+    for_each = var.auto_rollout ? [true] : []
+    content {
+      strategy = "Rolling"
+      preferences {
+        # network interface needs to be freed, before it can be attached to a new instance
+        min_healthy_percentage = 0
+      }
+    }
+  }
+
   enabled_metrics = [
     "GroupMinSize",
     "GroupMaxSize",

--- a/ec2.tf
+++ b/ec2.tf
@@ -123,7 +123,7 @@ resource "aws_instance" "main" {
 
   launch_template {
     id      = aws_launch_template.main.id
-    version = aws_launch_template.main.latest_version
+    version = var.auto_rollout ? aws_launch_template.main.latest_version : "$Latest"
   }
 
   tags = var.tags

--- a/ec2.tf
+++ b/ec2.tf
@@ -123,7 +123,7 @@ resource "aws_instance" "main" {
 
   launch_template {
     id      = aws_launch_template.main.id
-    version = "$Latest"
+    version = aws_launch_template.main.latest_version
   }
 
   tags = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,12 @@ variable "ha_mode" {
   default     = true
 }
 
+variable "auto_rollout" {
+  description = "Whether to automatically rollout configuration changes to the launch template (like AMI and cloud init)"
+  type        = bool
+  default     = false # backward compatible with v1
+}
+
 variable "instance_type" {
   description = "Instance type to use for the NAT instance"
   type        = string


### PR DESCRIPTION
Currently changing the launch template by configuring `ami_id` or `cloud_init_parts` creates a new version for the launch template, but the EC2 instance still use the old version.

I would expect that after terraform finishes, a new EC2 instance is running with the new launch template's configuration.

This PR fixes the issue by making the launch template version explicit and thereby forcing a change in the asg or ec2 configuration.