### PR TITLE
Add optional permissions boundary support for IAM role

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -133,9 +133,10 @@ data "aws_iam_policy_document" "instance_assume_role_policy" {
 }
 
 resource "aws_iam_role" "main" {
-  name               = var.name
-  assume_role_policy = data.aws_iam_policy_document.instance_assume_role_policy.json
-  tags               = var.tags
+  name                 = var.name
+  assume_role_policy   = data.aws_iam_policy_document.instance_assume_role_policy.json
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -183,6 +183,12 @@ variable "ssh_cidr_blocks" {
   }
 }
 
+variable "permissions_boundary_arn" {
+  description = "ARN of the IAM policy to use as a permissions boundary for the NAT instance IAM role"
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "Tags to apply to resources created within the module"
   type        = map(string)


### PR DESCRIPTION

Adds a new permissions_boundary_arn variable that allows optionally attaching an IAM permissions boundary to the NAT instance role.

This is useful in environments where SCPs (Service Control Policies) or internal governance policies require all IAM roles to have a permissions boundary set. Without it, role creation would be denied outright. By defaulting to null, this change is fully backwards-compatible and has no effect on existing deployments.

Usage:
```
module "fck-nat" {
  source = "RaJiska/fck-nat/aws"

  permissions_boundary_arn = "arn:aws:iam::123456789012:policy/MyPermissionsBoundary"
  # ...
}