### PR TITLE
fix: make module compatible with AWS provider 5.x and Terraform 1.7.5

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -1,8 +1,6 @@
 resource "aws_autoscaling_group" "main" {
   count = var.ha_mode ? 1 : 0
 
-  region = var.region
-
   name                = var.name
   max_size            = 1
   min_size            = 1

--- a/ec2.tf
+++ b/ec2.tf
@@ -1,8 +1,6 @@
 data "aws_ami" "main" {
   count = var.ami_id != null ? 0 : 1
 
-  region = var.region
-
   most_recent = true
   owners      = ["568608671756"]
 
@@ -61,7 +59,6 @@ data "cloudinit_config" "this" {
 
 resource "aws_launch_template" "main" {
   #checkov:skip=CKV_AWS_88:NAT instances must have a public IP.
-  region = var.region
 
   name          = var.name
   image_id      = local.ami_id
@@ -127,8 +124,6 @@ resource "aws_launch_template" "main" {
 resource "aws_instance" "main" {
   #checkov:skip=CKV2_AWS_41:False positive, IAM role is attached via the launch template.
   count = var.ha_mode ? 0 : 1
-
-  region = var.region
 
   launch_template {
     id      = aws_launch_template.main.id

--- a/iam.tf
+++ b/iam.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "main" {
         "ec2:DisassociateAddress",
       ]
       resources = [
-        "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:elastic-ip/${var.eip_allocation_ids[0]}",
+        "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:elastic-ip/${var.eip_allocation_ids[0]}",
       ]
     }
   }
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "main" {
         "ec2:DisassociateAddress",
       ]
       resources = [
-        "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:network-interface/*"
+        "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:network-interface/*"
       ]
       condition {
         test     = "StringEquals"

--- a/main.tf
+++ b/main.tf
@@ -7,22 +7,17 @@ locals {
   instance_name      = lookup(var.tags, "Name", var.name)
 }
 
-data "aws_region" "current" {
-  region = var.region
-}
+data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
 data "aws_vpc" "main" {
-  region = var.region
-
   id = var.vpc_id
 }
 
 resource "aws_security_group" "main" {
   #checkov:skip=CKV_AWS_24:False positive, ingress CIDR blocks on port 22 default to "[]"
   #checkov:skip=CKV_AWS_382:Security group is used for NAT instance, intended to egress to the world
-  region = var.region
 
   name        = var.name
   description = "Used in ${var.name} instance of fck-nat in subnet ${var.subnet_id}"
@@ -63,7 +58,6 @@ resource "aws_security_group" "main" {
 }
 
 resource "aws_network_interface" "main" {
-  region = var.region
 
   description        = "${var.name} static private ENI"
   subnet_id          = var.subnet_id
@@ -77,8 +71,6 @@ resource "aws_network_interface" "main" {
 resource "aws_route" "main" {
   for_each = var.update_route_tables || var.update_route_table ? merge(var.route_tables_ids, var.route_table_id != null ? { RESERVED_FKC_NAT = var.route_table_id } : {}) : {}
 
-  region = var.region
-
   route_table_id         = each.value
   destination_cidr_block = "0.0.0.0/0"
   network_interface_id   = aws_network_interface.main.id
@@ -87,8 +79,6 @@ resource "aws_route" "main" {
 resource "aws_route" "main_ipv6" {
   for_each = (var.update_route_tables || var.update_route_table) && var.use_nat64 ? var.route_tables6_ids : {}
 
-  region = var.region
-
   route_table_id              = each.value
   destination_ipv6_cidr_block = "64:ff9b::/96"
   network_interface_id        = aws_network_interface.main.id
@@ -96,8 +86,6 @@ resource "aws_route" "main_ipv6" {
 
 resource "aws_ssm_parameter" "cloudwatch_agent_config" {
   count = var.use_cloudwatch_agent && var.cloudwatch_agent_configuration_param_arn == null ? 1 : 0
-
-  region = var.region
 
   name   = "${var.name}-cloudwatch-agent-config"
   key_id = var.kms_key_id

--- a/provider.tf
+++ b/provider.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0" # Required for region variable on resources
+      version = ">= 5.80" # brilliant fork: relaxed from >= 6.0; per-resource region args stripped for provider 5.x / Atlantis TF 1.7.5
     }
   }
-  required_version = "~> 1.9" # For cross-object referencing on variables validation
+  required_version = "~> 1.3" # brilliant fork: relaxed from ~> 1.9; cross-variable validation removed for TF 1.7.5
 }

--- a/variables.tf
+++ b/variables.tf
@@ -83,11 +83,7 @@ variable "ha_additional_instance_types" {
   description = "List of additional instance types to pass to the ASG, helpful when using spot instances with low availabiltiy"
   type        = list(string)
   default     = []
-
-  validation {
-    condition     = var.ha_mode || (!var.ha_mode && length(var.ha_additional_instance_types) == 0)
-    error_message = "You must set ha_mode to true to use multiple instance types."
-  }
+  # brilliant fork: removed cross-variable validation (var.ha_mode reference) — requires TF 1.9+, Atlantis runs 1.7.5
 }
 
 variable "ami_id" {


### PR DESCRIPTION
Our Atlantis pins Terraform v1.7.5 and the VPC stack uses AWS provider ~> 5.80. Upstream v1.6.0 requires provider >= 6.0 and TF ~> 1.9, and uses both load-bearing — so a constraint relax alone is insufficient.

- Strip per-resource `region = var.region` args (provider 6 only) from all resources/data sources; the provider's configured region applies.
- Change `data.aws_region.current.region` -> `.name` (`.region` is v6).
- Remove the cross-variable validation on `ha_additional_instance_types` (references var.ha_mode; TF 1.9+ only).
- Relax provider constraint to >= 5.80 and required_version to ~> 1.3.

The `region` input variable is retained (unused) to preserve the module interface for callers. Revert to upstream RaJiska v1.6.0 if/when the VPC stack moves to AWS provider 6.x.