### PR TITLE
feat: allow custom fck-nat.conf entries and user data env vars via map variables

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -46,6 +46,8 @@ data "cloudinit_config" "this" {
       TERRAFORM_EIP_ID                 = length(var.eip_allocation_ids) != 0 ? var.eip_allocation_ids[0] : ""
       TERRAFORM_CWAGENT_ENABLED        = var.use_cloudwatch_agent ? "true" : ""
       TERRAFORM_CWAGENT_CFG_PARAM_NAME = local.cwagent_param_name != null ? local.cwagent_param_name : ""
+      TERRAFORM_ENV_VARS               = var.user_data_env_vars
+      TERRAFORM_ADDITIONAL_CONFIG      = var.additional_fck_nat_configuration
     })
   }
 

--- a/templates/user_data.sh
+++ b/templates/user_data.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
+%{ for key, value in TERRAFORM_ENV_VARS ~}
+export ${key}="${value}"
+%{ endfor ~}
 
 : > /etc/fck-nat.conf
 echo "eni_id=${TERRAFORM_ENI_ID}" >> /etc/fck-nat.conf
 echo "eip_id=${TERRAFORM_EIP_ID}" >> /etc/fck-nat.conf
 echo "cwagent_enabled=${TERRAFORM_CWAGENT_ENABLED}" >> /etc/fck-nat.conf
 echo "cwagent_cfg_param_name=${TERRAFORM_CWAGENT_CFG_PARAM_NAME}" >> /etc/fck-nat.conf
+%{ for key, value in TERRAFORM_ADDITIONAL_CONFIG ~}
+echo "${key}=${value}" >> /etc/fck-nat.conf
+%{ endfor ~}
 
 service fck-nat restart

--- a/variables.tf
+++ b/variables.tf
@@ -214,3 +214,15 @@ variable "cloud_init_parts" {
   }))
   default = []
 }
+
+variable "additional_fck_nat_configuration" {
+  description = "Additional key/value pairs to append to /etc/fck-nat.conf"
+  type        = map(string)
+  default     = {}
+}
+
+variable "user_data_env_vars" {
+  description = "Environment variables to export at the start of the user data script"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
 ## What                                                                                                                                                                                                           
                                                                                                                                                                                                                    
  Adds two new optional `map(string)` variables for customizing the generated user data script:                                                                                                                     
                                                                                                                                                                                                                    
  - **`additional_fck_nat_configuration`** — key/value pairs appended as `key=value` lines to `/etc/fck-nat.conf`, after the built-in entries (`eni_id`, `eip_id`, `cwagent_enabled`, `cwagent_cfg_param_name`) and 
  before `service fck-nat restart`.                                                                                                                                                                                 
  - **`user_data_env_vars`** — key/value pairs exported as shell environment variables (`export KEY="value"`) at the top of the user data script, useful for things like proxy settings.                            
                                                                                                                                                                                                                    
  ## Why   
Previously the set of values written to `/etc/fck-nat.conf` was hardcoded in the `templatefile()` call. The only way to add custom configuration was to replace the whole cloud-init part via `cloud_init_parts`, 
  which duplicates the built-in script. This lets consumers extend the config file and script environment without replacing it.                                                                                     
                                                                                                                                                                                                                    
  ## Usage                                                                                                                                                                                                          
                                                                                                                                                                                                                    
  ```hcl                                                                                                                                                                                                            
  module "fck-nat" {                                                                                                                                                                                                
    # ...                                                                                                                                                                                                           
                                                                                                                                                                                                                    
    additional_fck_nat_configuration = {                                                                                                                                                                            
      my_setting = "foo"                        
  }                                                                                                                                                                                                               
                                                                                                                                                                                                                    
    user_data_env_vars = {                                                                                                                                                                                          
      HTTP_PROXY = "http://proxy.internal:3128"                                                                                                                                                                     
    }                                                                                                                                                                                                               
  }                                                                                                                                                                                                                 
                                                                                                                                                                                                                    
  Backwards compatibility                                                                                                                                                                                           
                                                                                                                                                                                                                    
  Both variables default to {}. The rendered user data is byte-identical to the previous template when the maps are empty (verified by diffing templatefile() output of the old and new templates), so existing     
  deployments see no launch template diff.                                                                                                                                                                          
                                                                                                                                                                                                                    