### PR TITLE
Fix CWAgent Param Name Parsing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ locals {
   is_arm             = can(regex("[a-zA-Z]+\\d+g[a-z]*\\..+", var.instance_type))
   ami_id             = var.ami_id != null ? var.ami_id : data.aws_ami.main[0].id
   cwagent_param_arn  = var.use_cloudwatch_agent ? var.cloudwatch_agent_configuration_param_arn != null ? var.cloudwatch_agent_configuration_param_arn : aws_ssm_parameter.cloudwatch_agent_config[0].arn : null
-  cwagent_param_name = var.use_cloudwatch_agent ? var.cloudwatch_agent_configuration_param_arn != null ? split("/", data.aws_arn.ssm_param[0].resource)[1] : aws_ssm_parameter.cloudwatch_agent_config[0].name : null
+  cwagent_param_name = var.use_cloudwatch_agent ? var.cloudwatch_agent_configuration_param_arn != null ? trimprefix(data.aws_arn.ssm_param[0].resource, "parameter") : aws_ssm_parameter.cloudwatch_agent_config[0].name : null
   security_groups    = concat(var.use_default_security_group ? [aws_security_group.main.id] : [], var.additional_security_group_ids)
   instance_name      = lookup(var.tags, "Name", var.name)
 }


### PR DESCRIPTION
CWAgent Param Name is derived from the SSM Pram ARN by splitting by slash and taking the first portion only. This breaks when hierarchical names are used failing to parse the full name of the parameter.

This change removes the `parameter` prefix from the resource portion of the ARN instead of splitting by slash so the full hierarchical name can be resolved with its leading slash.

Addresses issue https://github.com/RaJiska/terraform-aws-fck-nat/issues/86.